### PR TITLE
feat: update location page

### DIFF
--- a/src/app/api/location/route.ts
+++ b/src/app/api/location/route.ts
@@ -7,30 +7,53 @@ const KV_KEY = "work_locations";
 
 type LocationMap = Record<string, string>;
 
-// GET: 今日以降の勤務場所を取得（公開用）+ 古いエントリを自動削除
+function formatDateJST(date: Date): string {
+  return date.toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
+}
+
+// 昨日以前のエントリを削除 + 今日から2ヶ月後まで「未定（お問い合わせください）」を自動補填
+async function cleanAndFillEntries(): Promise<LocationMap> {
+  const todayStr = formatDateJST(new Date());
+
+  const raw = await getRedis().get(KV_KEY);
+  const data: LocationMap = raw ? JSON.parse(raw) : {};
+  const cleaned: LocationMap = {};
+
+  // 過去のエントリを除外
+  for (const [date, location] of Object.entries(data)) {
+    if (date >= todayStr) {
+      cleaned[date] = location;
+    }
+  }
+
+  // 今日から2ヶ月後まで、未登録の日に「未定（お問い合わせください）」を自動セット
+  const today = new Date();
+  const twoMonthsLater = new Date(today);
+  twoMonthsLater.setMonth(twoMonthsLater.getMonth() + 2);
+
+  const cursor = new Date(today);
+  let added = false;
+  while (formatDateJST(cursor) <= formatDateJST(twoMonthsLater)) {
+    const dateStr = formatDateJST(cursor);
+    if (!(dateStr in cleaned)) {
+      cleaned[dateStr] = "未定（お問い合わせください）";
+      added = true;
+    }
+    cursor.setDate(cursor.getDate() + 1);
+  }
+
+  if (added || Object.keys(cleaned).length !== Object.keys(data).length) {
+    await getRedis().set(KV_KEY, JSON.stringify(cleaned));
+  }
+
+  return cleaned;
+}
+
+// GET: 今日以降の勤務場所を取得（公開用）+ 未定の自動補填
 export async function GET() {
   try {
-    const todayStr = new Date().toLocaleDateString("sv-SE", { timeZone: "Asia/Tokyo" });
-
-    const raw = await getRedis().get(KV_KEY);
-    const data: LocationMap = raw ? JSON.parse(raw) : {};
-    const result: LocationMap = {};
-    let needsClean = false;
-
-    for (const [date, location] of Object.entries(data)) {
-      if (date >= todayStr) {
-        result[date] = location;
-      } else {
-        needsClean = true;
-      }
-    }
-
-    // 古いエントリがあれば削除
-    if (needsClean) {
-      await getRedis().set(KV_KEY, JSON.stringify(result));
-    }
-
-    return NextResponse.json({ ok: true, locations: result });
+    const data = await cleanAndFillEntries();
+    return NextResponse.json({ ok: true, locations: data });
   } catch (error) {
     console.error("Failed to get locations:", error);
     return NextResponse.json(

--- a/src/app/location/page.tsx
+++ b/src/app/location/page.tsx
@@ -174,7 +174,7 @@ export default function LocationPage() {
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.45, duration: 0.7 }}
         >
-          <Link href="/reserve" className="text-blue-300 hover:text-blue-200 underline underline-offset-2 transition-colors">
+          <Link href="/reserve" className="text-orange-300 hover:text-orange-200 underline underline-offset-2 transition-colors">
             Ask Me
           </Link>
           ページでの対面でのお問い合わせにご活用ください
@@ -182,7 +182,7 @@ export default function LocationPage() {
 
         {loading ? (
           <div className="flex items-center justify-center py-12">
-            <div className="h-8 w-8 animate-spin rounded-full border-4 border-white/30 border-t-white" />
+            <div className="h-8 w-8 animate-spin rounded-full border-4 border-orange-300/30 border-t-orange-400" />
           </div>
         ) : error ? (
           <p className="py-8 text-center text-red-300">{error}</p>
@@ -260,8 +260,8 @@ export default function LocationPage() {
                           ${!isCurrentMonth ? "opacity-20" : ""}
                           ${isPast && isCurrentMonth ? "opacity-30 cursor-not-allowed" : ""}
                           ${!isPast ? "cursor-pointer hover:bg-white/20" : "cursor-not-allowed"}
-                          ${today ? "ring-2 ring-blue-400" : ""}
-                          ${selected ? "bg-blue-500/30" : ""}
+                          ${today ? "ring-2 ring-orange-400" : ""}
+                          ${selected ? "bg-orange-500/30" : ""}
                           ${hasLocation ? "font-bold text-white" : "text-white/50"}
                         `}
                       >
@@ -300,11 +300,11 @@ export default function LocationPage() {
               <div className="mt-3 space-y-2">
                 <div className="flex flex-wrap items-center justify-center gap-x-5 gap-y-1 text-xs text-white/50">
                   <span className="flex items-center gap-1.5">
-                    <span className="inline-block h-3 w-3 rounded ring-2 ring-blue-400" />
+                    <span className="inline-block h-3 w-3 rounded ring-2 ring-orange-400" />
                     今日
                   </span>
                   <span className="flex items-center gap-1.5">
-                    <span className="inline-block h-3 w-3 rounded bg-blue-500/30" />
+                    <span className="inline-block h-3 w-3 rounded bg-orange-500/30" />
                     選択中
                   </span>
                   <span className="flex items-center gap-1.5">
@@ -341,7 +341,7 @@ export default function LocationPage() {
                     <motion.div
                       key={date}
                       className={`flex items-center justify-between px-6 py-4 cursor-pointer transition-colors hover:bg-white/5 ${
-                        isToday(date) ? "bg-blue-500/10" : ""
+                        isToday(date) ? "bg-orange-500/10" : ""
                       } ${date === displayDate ? "bg-white/5" : ""}`}
                       initial={{ opacity: 0, x: -20 }}
                       animate={{ opacity: 1, x: 0 }}
@@ -350,7 +350,7 @@ export default function LocationPage() {
                     >
                       <div className="flex items-center gap-3">
                         {isToday(date) && (
-                          <span className="rounded-full bg-blue-500 px-2 py-0.5 text-xs font-bold text-white">
+                          <span className="rounded-full bg-orange-500 px-2 py-0.5 text-xs font-bold text-white">
                             TODAY
                           </span>
                         )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -31,23 +31,19 @@ export function Header() {
         </div>
         <nav className="flex items-center gap-1 whitespace-nowrap">
           <Link
-            href="/"
-            onClick={() => {
-              // Homeボタンがクリックされた時にフラグを設定
-              sessionStorage.setItem('from_home', 'true');
-            }}
+            href="/location"
             className={cn(
               "relative group overflow-hidden rounded-lg px-3 py-2 text-sm font-medium transition-all duration-200",
-              isActive("/")
-                ? "bg-gradient-to-r from-red-600 to-pink-600 text-white shadow-lg shadow-red-500/25"
+              isActive("/location")
+                ? "bg-gradient-to-r from-orange-500 to-amber-500 text-white shadow-lg shadow-orange-500/25"
                 : isAnyLoading
                 ? "text-zinc-400 cursor-not-allowed"
                 : "text-zinc-700 hover:bg-gradient-to-r hover:from-zinc-100 hover:to-zinc-200 dark:text-zinc-300 dark:hover:from-zinc-800 dark:hover:to-zinc-700"
             )}
             style={{ pointerEvents: isAnyLoading ? 'none' : 'auto' }}
           >
-            <span className="relative z-20">Home</span>
-            {isActive("/") ? (
+            <span className="relative z-20">Schedule</span>
+            {isActive("/location") ? (
               <span className="pointer-events-none absolute top-1/2 right-0 -translate-y-1/2 translate-x-full opacity-0 transition-transform duration-300 ease-out group-hover:translate-x-1/2 group-hover:opacity-100 group-active:translate-x-1/2 group-active:opacity-100 z-10" aria-hidden="true">
                 <Image src="/qiitan.png" alt="Qiitan" width={30} height={30} className="h-[30px] w-[30px] -rotate-45" />
               </span>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> The `GET /api/location` route now mutates Redis data by deleting past entries and auto-populating up to two months of placeholder values, which could unexpectedly overwrite/expand stored data. UI/navigation changes are low risk but depend on the new placeholder behavior.
> 
> **Overview**
> **Location schedule API now self-maintains data.** `GET /api/location` was refactored to run `cleanAndFillEntries()`, which drops yesterday-and-earlier entries and *auto-populates* missing dates from today through two months out with `未定（お問い合わせください）`, persisting the updated map back to Redis.
> 
> **Location UI/navigation tweaks.** The location page switches key accents/spinner/today/selected highlights from blue to orange, and the header’s primary nav link is changed from `Home` (`/`) to `Schedule` (`/location`) with updated active styling (and removes the previous `sessionStorage` flag on click).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c319d14feecfeed3117c36a819f793e72c84bc1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->